### PR TITLE
Bug static urls

### DIFF
--- a/knowledge_repo/app/static/js/index-cluster.js
+++ b/knowledge_repo/app/static/js/index-cluster.js
@@ -64,7 +64,7 @@ var indexClusterJx = (function(){
                            .replace('sort', '')
                            .toLowerCase();
     var filter_var = $('#searchbar').val();
-    var loc = '/cluster?group_by=' + cluster + '&sort_by=' + sort;
+    var loc = '/ccbd24f370707c33603102adc7b77123/cluster?group_by=' + cluster + '&sort_by=' + sort;
     if (sort === "alpha") {
       loc += "&sort_asc=1";
     }

--- a/knowledge_repo/app/templates/index-base.html
+++ b/knowledge_repo/app/templates/index-base.html
@@ -2,7 +2,7 @@
 
 {% macro format_authors(authors) %}
   {% for author in authors %}
-    <a href='/feed?authors={{ author.identifier|urlencode }}'>
+    <a href='{{url_for('index.render_feed')}}?authors={{ author.identifier|urlencode }}'>
       {{ author.format_name }}
     </a>
     {% if not loop.last %}

--- a/knowledge_repo/app/templates/index-cluster.html
+++ b/knowledge_repo/app/templates/index-cluster.html
@@ -50,7 +50,7 @@
   {%- for cluster, is_post, count, contents in grouped_data recursive %}
     {%- if is_post %}
       <li class="cluster_post" style="list-style-type:circle">
-        <a href="{{'/ccbd24f370707c33603102adc7b77123/post/' + contents.path|urlencode }}">
+        <a href="{{url_for('posts.render',path = contents.path)}}">
           {{ contents.title|replace('_', ' '|title )}}
         </a>
       </li>

--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -40,7 +40,7 @@
     {% for post in posts %}
     <div class="row feed-post" data-path='{{post.path|urlencode}}' data-url="{{url_for('posts.render', path=post.path)}}">
         <div class='feed-thumbnail'>
-            <img src="{{ post['thumbnail'] if post['thumbnail'] else '/static/images/default_thumbnail.png' }}" />
+            <img src="{{ post['thumbnail'] if post['thumbnail'] else url_for('admin.static', filename='/images/default_thumbnail.png') }}" />
         </div>
         <div class='feed-metadata'>
                 <span class="feed-title">{{ post.title }}</span>

--- a/knowledge_repo/app/templates/index-feed.html
+++ b/knowledge_repo/app/templates/index-feed.html
@@ -8,7 +8,7 @@
 {% macro render_tag(tag, post_id) %}
 
 {% set tag_flat = tag.replace("/", "__") %}
-    <a  href="/tag_pages?tag={{ tag|urlencode }}"
+    <a  href="{{url_for('tag.render_tag_pages')}}?tag={{ tag|urlencode }}"
         data-tag-name="{{ tag_flat }}"
         data-container="body"
         data-toggle="popover"

--- a/knowledge_repo/app/templates/index-table.html
+++ b/knowledge_repo/app/templates/index-table.html
@@ -50,7 +50,6 @@
     {% set stats = post_stats[post.path] %}
     <tr class="table-post">
       <td id="path-{{ idx_item }}">
-<!--        <a href="{{'/post/' + post.path|urlencode }}"> -->
         <a href="{{url_for('posts.render',path=post.path)}}">
           {{ post.title|replace('_', ' ')|title }}
         </a>
@@ -63,9 +62,9 @@
           {% for tag_obj in post.tags %}
             {% set tag = tag_obj.name %}
             {% if loop.last %}
-               <a href="/ccbd24f370707c33603102adc7b77123/tag_pages?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>
+               <a href="{{url_for('tag.render_tag_pages')}}?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>
               {% else %}
-               <a href="/ccbd24f370707c33603102adc7b77123/tag_pages?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>,
+               <a href="{{url_for('tag.render_tag_pages')}}?tag={{ tag|urlencode }}">{{ "#" + tag}}</a>,
               {% endif %}
           {% endfor %}
       </td>
@@ -75,7 +74,7 @@
             {%- set tldr = "(No TL;DR)" %}
           {%- endif %}
           <i>{{ tldr | truncate(100, True) }} </i>
-          <a href="{{'/ccbd24f370707c33603102adc7b77123/post/' + post.path|urlencode }}">
+          <a href="{{url_for('posts.render',path=post.path) }}">
             post.
           </a>
       </td>
@@ -153,7 +152,7 @@ $(document).ready(function(){
     $.each(col_names, function(i, col){
         var desc_sort = "#sortBy" + col + "Desc";
         var asc_sort = "#sortBy" + col + "Asc";
-        var new_location = '/ccbd24f370707c33603102adc7b77123/table?start=' + start.toString() + '&results=' + results.toString() + '&sort_by=' + col
+        var new_location = "{{url_for('index.render_table')}}?start=" + start.toString() + '&results=' + results.toString() + '&sort_by=' + col
         if(filters != 'None') {
           new_location = new_location + '&filters=' + filters
         }

--- a/knowledge_repo/app/templates/tag_pages.html
+++ b/knowledge_repo/app/templates/tag_pages.html
@@ -37,7 +37,7 @@
     <div class='row row-space-4 panel feed-post'>
       <div class='panel-header panel-light'>
         <div class = "col-md-10">
-          <a href="{{'/post/' + post.path|urlencode }}">
+          <a href="{{url_for('posts.render,path=post.path' }}">
             {{ post.title |title }}
           </a>
         </div>
@@ -56,7 +56,7 @@
               {% for tag_obj in post.tags %}
                 {% set tag = tag_obj.name %}
                 {% set tag_flat = tag.replace("/", "__") %}
-                <a  href="/tag_pages?tag={{ tag|urlencode }}"
+                <a  href="{{'tag.render_tag_pages'}}?tag={{ tag|urlencode }}"
                     data-tag-name="{{ tag_flat }}"
                     data-container="body"
                     data-toggle="popover"
@@ -89,7 +89,7 @@
             <i>{{ post['tldr']|safe }}</i>
             <br>
             <br>
-            <a href="{{'/post/' + post.path|urlencode }}">Read post</a>
+            <a href="{{url_for('posts.render',path=post.path) }}">Read post</a>
           </p>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
In a lot of places, hard coded URLs were used in KR. they had to be fixed to adjust for our application root. Fixes have been done in all places that our application currently serves. 

There is one exception of a cluster.js file which needs a harcoded URL since it is not Jinja Templated. 
Ideally we should put it in a constants file but this looks like an exception so is being left for future