### PR TITLE
Some bug fixes

### DIFF
--- a/knowledge_repo/app/routes/tags.py
+++ b/knowledge_repo/app/routes/tags.py
@@ -118,10 +118,12 @@ def delete_tags_from_posts():
 @PageView.logged
 @permissions.post_comment.require()
 def render_tag_pages():
+    return render_template("permission_denied.html")
     feed_params = from_url_get_feed_params(request.url)
     start = feed_params['start']
     num_results = feed_params['results']
     tag = request.args.get('tag', '')
+    print(tag)
 
     if tag[0] == '#':
         tag = tag[1:]

--- a/knowledge_repo/app/templates/tag_pages.html
+++ b/knowledge_repo/app/templates/tag_pages.html
@@ -37,7 +37,7 @@
     <div class='row row-space-4 panel feed-post'>
       <div class='panel-header panel-light'>
         <div class = "col-md-10">
-          <a href="{{url_for('posts.render,path=post.path') }}">
+          <a href="{{url_for('posts.render',path='post.path') }}">
             {{ post.title |title }}
           </a>
         </div>

--- a/knowledge_repo/app/utils/requests.py
+++ b/knowledge_repo/app/utils/requests.py
@@ -35,6 +35,10 @@ def from_url_get_feed_params(url):
         if '%2F' in val:
           val=val.split('%2F')
           val=val[0]+'/'+val[1]
+
+        if '%40' in val:
+          val = val.split('%40')
+          val = val[0] + '@' + val[1]
         feed_params[query] = val
 
       

--- a/knowledge_repo/app/utils/requests.py
+++ b/knowledge_repo/app/utils/requests.py
@@ -46,6 +46,11 @@ def from_url_get_feed_params(url):
     feed_params["username"] = username
     feed_params["user_id"] = user_id
 
+    if 'start' in feed_params:
+      feed_params['start'] = int(feed_params['start'])
+    if 'results' in feed_params:
+      feed_params['results'] = int(feed_params['results'])
+
     user_obj = (db_session.query(User)
                           .filter(User.id == user_id)
                           .first())


### PR DESCRIPTION
Bugs fixed:
On clicking tags on a post, previously it was showing internal server error, now it is showing permission denied (for now)
Posts were not getting filtered whenever author's name had '@' in them
On going to next page it was showing error 
Description of changeset:
tags.py - added return to permission denied page
tag_pages.html - corrected url_for syntax
requests.py - added extra condition for '@' in name, made sure that start and results parameters of feed_params are integers